### PR TITLE
Add pytest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ for case in Case.select():
   print(case.docket, case.transcript)
 ```
 
+## Testing
+
+This project uses `pytest` for its automated test suite. After installing the
+dependencies, run the tests with:
+
+```bash
+pytest
+```
+
+The tests verify docket preprocessing and the configurable `VERBOSE` setting in
+`settings.py`.
+
 ## License
 
 Python SCOTUS Dataset is licensed under the

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+
+def _import_recon():
+    # Remove any existing modules that might interfere
+    for name in ['recon', 'models', 'transcripts', 'scdb']:
+        sys.modules.pop(name, None)
+
+    # Stub out heavy dependencies
+    models_stub = types.ModuleType('models')
+    class Dummy:
+        pass
+    models_stub.Transcript = Dummy
+    models_stub.Statement = Dummy
+    models_stub.Case = Dummy
+    sys.modules['models'] = models_stub
+
+    transcripts_stub = types.ModuleType('transcripts')
+    transcripts_stub.preprocess_all_transcripts = lambda: None
+    sys.modules['transcripts'] = transcripts_stub
+
+    scdb_stub = types.ModuleType('scdb')
+    scdb_stub.load_cases = lambda: None
+    sys.modules['scdb'] = scdb_stub
+
+    return importlib.import_module('recon')
+
+
+recon = _import_recon()
+
+
+@pytest.mark.parametrize(
+    'raw,expected', [
+        ('A-123 ORIG', '123'),
+        ('12-345 (Original)', '12-345'),
+        ('10-100, ORIG', '10-100'),
+        ('16-123 ORIG ORIG', '16-123'),
+        ('A-100', '100'),
+        ('12-345 M', '12-345'),
+    ]
+)
+def test_preprocess_docket(raw, expected):
+    assert recon.preprocess_docket(raw) == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+def reload_settings():
+    sys.modules.pop('settings', None)
+    return importlib.import_module('settings')
+
+def test_verbose_default_true(monkeypatch):
+    monkeypatch.delenv('VERBOSE', raising=False)
+    settings = reload_settings()
+    assert settings.VERBOSE is True
+
+def test_verbose_env_override(monkeypatch):
+    monkeypatch.setenv('VERBOSE', '0')
+    settings = reload_settings()
+    assert settings.VERBOSE == '0'


### PR DESCRIPTION
## Summary
- add tests for `preprocess_docket` using stubbed dependencies to isolate function behavior
- verify `settings.VERBOSE` default and environment override
- document how to run the test suite in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893da44bf1483268e7b1a3bc60bcdfd