### PR TITLE
Add tests for paragraph and red flag behavior

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,9 @@
 import os
 import sys
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from models import aggressively_sanitize_string, Statement, Transcript
+from models import aggressively_sanitize_string, RedFlag, Statement, Transcript
 
 
 def make_statement(speaker: str) -> Statement:
@@ -26,3 +24,26 @@ def test_speaker_is_justice_true_cases():
 
 def test_speaker_is_justice_false_case():
     assert not make_statement("MR. SMITH").speaker_is_justice()
+
+
+def test_add_paragraph_sanitizes_and_full_text():
+    transcript = Transcript(
+        raw_text="", term=2021, docket="2", file_name="g"
+    ).get_or_create()
+    statement = Statement(transcript=transcript, speaker="MR. SMITH").get_or_create()
+    statement.add_paragraph("Hello\u2603")
+    statement.add_paragraph("Hello\u2603")  # duplicate, should not add twice
+    statement.add_paragraph("Second")
+    assert statement.paragraphs() == ["Hello", "Second"]
+    assert statement.full_text() == "Hello\n\nSecond"
+
+
+def test_add_red_flag_dedupes():
+    transcript = Transcript(
+        raw_text="", term=2022, docket="3", file_name="h"
+    ).get_or_create()
+    transcript.add_red_flag("Issue")
+    transcript.add_red_flag("Issue")  # duplicate
+    assert transcript.has_red_flags()
+    assert transcript.red_flags() == ["Issue"]
+    assert RedFlag.select().where(RedFlag.transcript == transcript).count() == 1


### PR DESCRIPTION
## Summary
- test statement paragraph sanitization and full-text rendering
- test transcript red flag creation is deduplicated

## Testing
- `uv run --extra dev pre-commit run --files tests/test_models.py`

------
https://chatgpt.com/codex/tasks/task_e_6893f3c3b7ec83269bb89bc6176c6fb9