### PR TITLE
refactor: replace bare exceptions in reconciliation

### DIFF
--- a/recon.py
+++ b/recon.py
@@ -18,13 +18,15 @@ def reconciliate_cases_and_transcripts():
     for case in Case.select():
         try:
             case_dockets[preprocess_docket(case.docket)] = case
-        except:
+        except (AttributeError, TypeError) as exc:
+            logging.debug("Skipping case without docket: %s", exc)
             continue
 
     for transcript in Transcript.select():
         try:
             transcript_dockets[preprocess_docket(transcript.docket)] = transcript
-        except:
+        except (AttributeError, TypeError) as exc:
+            logging.debug("Skipping transcript without docket: %s", exc)
             continue
 
     for docket in case_dockets:

--- a/scdb.py
+++ b/scdb.py
@@ -2,6 +2,7 @@ import pandas as pd
 import logging
 
 from settings import SCDB_FILE_PATH, VERBOSE
+from models import Case
 
 
 def __build_case(row):

--- a/settings.py
+++ b/settings.py
@@ -3,10 +3,31 @@ from __future__ import annotations
 import os
 from typing import Final
 
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Return a boolean parsed from environment variable ``name``.
+
+    Recognizes common truthy strings ("1", "true", "yes", "on") and
+    falsy strings ("0", "false", "no", "off"), case-insensitively.
+    Unrecognized values fall back to ``default``.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    return default
+
+
 DATA_DIR_PATH: Final[str] = os.path.join(os.path.dirname(__file__), "data")
 TRANSCRIPTS_DIR_PATH: Final[str] = os.path.join(DATA_DIR_PATH, "transcripts")
 SCDB_FILE_PATH: Final[str] = os.path.join(
     DATA_DIR_PATH, "SCDB_2019_01_caseCentered_Docket.csv"
 )
 DATABASE_FILE_PATH: Final[str] = os.path.join(DATA_DIR_PATH, "db.sqlite")
-VERBOSE: Final[bool] = bool(os.environ.get("VERBOSE", True))
+VERBOSE: Final[bool] = _env_flag("VERBOSE", True)

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -1,0 +1,35 @@
+import types
+import pytest
+import recon
+
+
+class Dummy:
+    pass
+
+
+def test_reconciliation_skips_objects_without_docket(monkeypatch):
+    case_missing = Dummy()
+    transcript_missing = Dummy()
+
+    monkeypatch.setattr(
+        recon, "Case", types.SimpleNamespace(select=lambda: [case_missing])
+    )
+    monkeypatch.setattr(
+        recon, "Transcript", types.SimpleNamespace(select=lambda: [transcript_missing])
+    )
+
+    recon.reconciliate_cases_and_transcripts()
+
+
+def test_reconciliation_propagates_unexpected_errors(monkeypatch):
+    class Bad:
+        @property
+        def docket(self):
+            raise ValueError("boom")
+
+    bad_case = Bad()
+    monkeypatch.setattr(recon, "Case", types.SimpleNamespace(select=lambda: [bad_case]))
+    monkeypatch.setattr(recon, "Transcript", types.SimpleNamespace(select=list))
+
+    with pytest.raises(ValueError):
+        recon.reconciliate_cases_and_transcripts()

--- a/tests/test_scdb.py
+++ b/tests/test_scdb.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+import scdb  # noqa: E402
+from models import Case  # noqa: E402
+
+
+def test_build_case_returns_case() -> None:
+    row = SimpleNamespace(
+        decisionType=1,
+        voteId="1",
+        term=2020,
+        docket="123",
+        chief="Roberts",
+        dateDecision="01/02/2020",
+    )
+    case = scdb.__build_case(row)
+    assert isinstance(case, Case)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,39 @@
+import importlib
+import pathlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+
+def reload_settings(monkeypatch: pytest.MonkeyPatch, value: str | None) -> ModuleType:
+    """Reload ``settings`` with ``VERBOSE`` set to ``value``.
+
+    ``value`` may be ``None`` to unset the environment variable.
+    """
+
+    if value is None:
+        monkeypatch.delenv("VERBOSE", raising=False)
+    else:
+        monkeypatch.setenv("VERBOSE", value)
+
+    import settings
+
+    return importlib.reload(settings)
+
+
+def test_verbose_true_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert reload_settings(monkeypatch, "true").VERBOSE is True
+    assert reload_settings(monkeypatch, "1").VERBOSE is True
+
+
+def test_verbose_false_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert reload_settings(monkeypatch, "false").VERBOSE is False
+    assert reload_settings(monkeypatch, "0").VERBOSE is False
+
+
+def test_verbose_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert reload_settings(monkeypatch, None).VERBOSE is True


### PR DESCRIPTION
## Summary
- handle missing docket fields explicitly when reconciling cases with transcripts
- parse VERBOSE env flag for common true/false values
- import Case model in SCDB loader to avoid NameError
- log skipped cases/transcripts lacking docket and test that unexpected errors surface

## Testing
- `uv run --extra dev pre-commit run --files scdb.py tests/test_scdb.py settings.py tests/test_settings.py`
- `uv run --extra dev pre-commit run --files recon.py tests/test_recon.py`


------
https://chatgpt.com/codex/tasks/task_e_6893d8fbb7c483269f2abc924ddc34df