### PR TITLE
Parse VERBOSE env var as boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ pytest
 ```
 
 The tests verify docket preprocessing and the configurable `VERBOSE` setting in
-`settings.py`.
+`settings.py`. The verbosity flag defaults to enabled; set the environment
+variable `VERBOSE` to `0`, `false`, or `no` to disable progress output.
 
 ## Contributing
 

--- a/recon.py
+++ b/recon.py
@@ -1,0 +1,13 @@
+import scotus_dataset.recon as _recon
+
+preprocess_docket = _recon.preprocess_docket
+reconciliate_cases_and_transcripts = _recon.reconciliate_cases_and_transcripts
+print_coverage_stats = _recon.print_coverage_stats
+compile_data = _recon.compile_data
+
+__all__ = [
+    "preprocess_docket",
+    "reconciliate_cases_and_transcripts",
+    "print_coverage_stats",
+    "compile_data",
+]

--- a/scotus_dataset/models.py
+++ b/scotus_dataset/models.py
@@ -19,8 +19,17 @@ DATABASE = SqliteDatabase(DATABASE_FILE_PATH)
 ## Utility functions ##########################################################################################################################
 
 
-def aggressively_sanitize_string(string):
-    return "".join([char if ord(char) < 128 else "" for char in string])
+def aggressively_sanitize_string(text: str) -> str:
+    """Remove non-ASCII characters from ``text``.
+
+    Args:
+        text: Input string that may contain non-ASCII characters.
+
+    Returns:
+        The input string with any characters outside the ASCII range removed.
+    """
+
+    return "".join(char for char in text if ord(char) < 128)
 
 
 ## Models #####################################################################################################################################

--- a/scotus_dataset/scdb.py
+++ b/scotus_dataset/scdb.py
@@ -5,7 +5,9 @@ from .settings import SCDB_FILE_PATH, VERBOSE
 from .models import Case
 
 
-def __build_case(row):
+def __build_case(row: pd.Series) -> Case:
+    """Create a :class:`Case` instance from a SCDB CSV row."""
+
     case_obj = Case()
     case_obj.decision_label = row.decisionType
     case_obj.vote_id = row.voteId
@@ -19,7 +21,9 @@ def __build_case(row):
     return case_obj
 
 
-def load_cases():
+def load_cases() -> None:
+    """Load SCDB cases from CSV into the database."""
+
     case_df = pd.read_csv(SCDB_FILE_PATH, engine="python")
     for index, row in case_df.iterrows():
         if VERBOSE:

--- a/scotus_dataset/settings.py
+++ b/scotus_dataset/settings.py
@@ -10,4 +10,19 @@ SCDB_FILE_PATH: Final[str] = os.path.join(
     DATA_DIR_PATH, "SCDB_2019_01_caseCentered_Docket.csv"
 )
 DATABASE_FILE_PATH: Final[str] = os.path.join(DATA_DIR_PATH, "db.sqlite")
-VERBOSE: Final[bool] = bool(os.environ.get("VERBOSE", True))
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Return ``True`` if the environment variable is truthy.
+
+    The check is case insensitive and treats ``1``, ``true``, ``yes``, ``y`` and
+    ``t`` as truthy values. Any other non-empty string is considered ``False``.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "t"}
+
+
+VERBOSE: Final[bool] = _env_flag("VERBOSE", default=True)

--- a/scotus_dataset/transcripts.py
+++ b/scotus_dataset/transcripts.py
@@ -335,7 +335,9 @@ def __preprocess_transcript(file_path):
     return transcript
 
 
-def preprocess_all_transcripts():
+def preprocess_all_transcripts() -> None:
+    """Parse all transcript files into the database."""
+
     for dir_path in __list_dir(TRANSCRIPTS_DIR_PATH):
         term = dir_path[-4:]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,12 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from scotus_dataset.models import aggressively_sanitize_string, Statement, Transcript
+from scotus_dataset.models import (
+    aggressively_sanitize_string,
+    Statement,
+    Transcript,
+    RedFlag,
+)
 
 
 def make_statement(speaker: str) -> Statement:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,16 +1,29 @@
 import importlib
+import pathlib
 import sys
 
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+
 def reload_settings():
-    sys.modules.pop('settings', None)
-    return importlib.import_module('settings')
+    sys.modules.pop("scotus_dataset.settings", None)
+    return importlib.import_module("scotus_dataset.settings")
+
 
 def test_verbose_default_true(monkeypatch):
-    monkeypatch.delenv('VERBOSE', raising=False)
+    monkeypatch.delenv("VERBOSE", raising=False)
     settings = reload_settings()
     assert settings.VERBOSE is True
 
+
 def test_verbose_env_override(monkeypatch):
-    monkeypatch.setenv('VERBOSE', '0')
+    monkeypatch.setenv("VERBOSE", "0")
     settings = reload_settings()
-    assert settings.VERBOSE == '0'
+    assert settings.VERBOSE is False
+
+
+def test_verbose_env_truthy(monkeypatch):
+    monkeypatch.setenv("VERBOSE", "1")
+    settings = reload_settings()
+    assert settings.VERBOSE is True


### PR DESCRIPTION
## Summary
- interpret VERBOSE environment variable using typical boolean strings
- document how to disable verbose logging with VERBOSE=0
- add tests for VERBOSE env parsing
- clarify utility helpers with type hints and docstrings
- expose recon utilities at module top level for tests
- document reconciliation and data-loading helpers

## Testing
- `uv run --extra dev pre-commit run --files scotus_dataset/recon.py scotus_dataset/scdb.py scotus_dataset/transcripts.py`
- `uv run --extra dev pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948bca840483269c9b137ac1e535d0